### PR TITLE
Add Vitest smoke test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest --run",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -24,6 +25,7 @@
     "globals": "^15.9.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^2.0.5"
   }
 }

--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import App from '../App';
+
+describe('App', () => {
+  it('is a function component', () => {
+    expect(typeof App).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- add a vitest-run test script so the CI job can execute unit tests
- introduce vitest as a dev dependency and add a simple smoke test for the App component

## Testing
- npm run test *(fails locally: vitest binary unavailable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68defa09f004832cb3de73b3c8281dbb