### PR TITLE
Fix smoke test import resolution

### DIFF
--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import App from '../App';
+import App from '../App.tsx';
 
 describe('App', () => {
   it('is a function component', () => {

--- a/src/types/vitest.d.ts
+++ b/src/types/vitest.d.ts
@@ -1,0 +1,7 @@
+declare module 'vitest' {
+  export function describe(name: string, fn: () => void): void;
+  export function it(name: string, fn: () => void): void;
+  export function expect(value: unknown): {
+    toBe(expected: unknown): void;
+  };
+}


### PR DESCRIPTION
## Summary
- update the smoke test to import the App component with an explicit .tsx extension for bundler resolution
- add a minimal Vitest module declaration so TypeScript can type-check the smoke test without the upstream typings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df09b64de8832c939cfb10e8c100ab